### PR TITLE
feat(drivers): universal disk devices API

### DIFF
--- a/build/src/components/build.rs
+++ b/build/src/components/build.rs
@@ -22,7 +22,7 @@ pub enum BuildEvent {
     StepFailed(String, String),
 }
 
-const DEFAULT_DISK_IMAGE_SIZE: u32 = 256 * 1024 * 1024;
+const DEFAULT_DISK_IMAGE_SIZE: u32 = 5 * 1024 * 1024;
 
 pub type BuildResult = Result<(), BuildError>;
 
@@ -108,7 +108,7 @@ impl BuildStep for ImageDiskBuild {
         gpt_disk
             .add_partition(
                 "kernelfs",
-                1024 * 1024 * 62,
+                1024 * 1024 * 1,
                 gpt::partition_types::BASIC,
                 0,
                 None,
@@ -118,7 +118,7 @@ impl BuildStep for ImageDiskBuild {
         gpt_disk
             .add_partition(
                 "rootfs",
-                1024 * 1024 * 128,
+                1024 * 1024 * 2,
                 gpt::partition_types::LINUX_FS,
                 0,
                 None,

--- a/src/drivers/ahci/port.rs
+++ b/src/drivers/ahci/port.rs
@@ -158,8 +158,8 @@ impl HBAPort {
 
         while self.device_busy() || self.device_drq() {}
 
-        self.port_command_set_issued(cmd_slot as u8);
         SATA_COMMAND_QUEUE.lock().insert(cmd_slot as u8, cmd);
+        self.port_command_set_issued(cmd_slot as u8);
 
         cmd_slot
     }

--- a/src/drivers/generics/dev_disk.rs
+++ b/src/drivers/generics/dev_disk.rs
@@ -1,3 +1,4 @@
+use crate::drivers::ahci::ahci_devices;
 use crate::drivers::ide::ata_pio::{ata_devices, AtaIoRequest};
 use crate::drivers::ide::AtaDeviceIdentifier;
 use crate::fs::partitions::Partition;
@@ -21,9 +22,10 @@ pub fn get_sata_drive(id: AtaDeviceIdentifier) -> Option<SataDevice> {
             identifier: id.clone(),
             inner: ata_devices().read().get(&id)?.clone(),
         }),
-        SataDeviceType::AHCI => {
-            todo!()
-        }
+        SataDeviceType::AHCI => Some(SataDevice {
+            identifier: id.clone(),
+            inner: ahci_devices().read().get(&id)?.clone(),
+        }),
     }
 }
 

--- a/src/drivers/generics/dev_disk.rs
+++ b/src/drivers/generics/dev_disk.rs
@@ -1,5 +1,57 @@
-use crate::drivers::ide::ata_pio::AtaIoRequest;
+use crate::drivers::ide::ata_pio::{ata_devices, AtaIoRequest};
+use crate::drivers::ide::AtaDeviceIdentifier;
+use crate::fs::partitions::Partition;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+
+pub struct SataDevice {
+    identifier: AtaDeviceIdentifier,
+    inner: Arc<dyn DiskDevice>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum SataDeviceType {
+    IDE,
+    AHCI,
+}
+
+pub fn get_sata_drive(id: AtaDeviceIdentifier) -> Option<SataDevice> {
+    match id.disk_type {
+        SataDeviceType::IDE => Some(SataDevice {
+            identifier: id.clone(),
+            inner: ata_devices().read().get(&id)?.clone(),
+        }),
+        SataDeviceType::AHCI => {
+            todo!()
+        }
+    }
+}
+
+impl DiskDevice for SataDevice {
+    fn read(&self, start_lba: u64, sectors_count: u16) -> AtaIoRequest {
+        self.inner.read(start_lba, sectors_count)
+    }
+
+    fn write(&self, start_lba: u64, sectors_count: u16, data: Vec<u8>) -> AtaIoRequest {
+        self.inner.write(start_lba, sectors_count, data)
+    }
+
+    fn partitions(&self) -> &Vec<Partition> {
+        self.inner.partitions()
+    }
+
+    fn identifier(&self) -> AtaDeviceIdentifier {
+        self.identifier
+    }
+
+    fn max_sector(&self) -> usize {
+        self.inner.max_sector()
+    }
+
+    fn logical_sector_size(&self) -> u64 {
+        self.inner.logical_sector_size()
+    }
+}
 
 pub trait DiskDevice {
     /// Reads `sectors_count` sectors from this drive, starting at `start_lba`, into `buffer`.
@@ -35,4 +87,12 @@ pub trait DiskDevice {
     /// get_sata_drive(0).lock().write(0, 4, &buffer);
     /// ```
     fn write(&self, start_lba: u64, sectors_count: u16, data: Vec<u8>) -> AtaIoRequest;
+
+    fn partitions(&self) -> &Vec<Partition>;
+
+    fn identifier(&self) -> AtaDeviceIdentifier;
+
+    fn max_sector(&self) -> usize;
+
+    fn logical_sector_size(&self) -> u64;
 }

--- a/src/drivers/ide/ata_pio.rs
+++ b/src/drivers/ide/ata_pio.rs
@@ -1120,9 +1120,9 @@ pub(super) trait AtaRegister: From<u8> + Into<u8> {
 }
 
 #[derive(Debug)]
-pub(super) struct AtaError {
-    pub(super) code: AtaErrorCode,
-    pub(super) lba: u64,
+pub(in crate::drivers) struct AtaError {
+    pub(in crate::drivers) code: AtaErrorCode,
+    pub(in crate::drivers) lba: u64,
 }
 
 impl AtaError {
@@ -1132,7 +1132,7 @@ impl AtaError {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(super) enum AtaErrorCode {
+pub(in crate::drivers) enum AtaErrorCode {
     CommandAbort,
     DriveNotPresent,
     InvalidBufferSize,

--- a/src/drivers/pci/device.rs
+++ b/src/drivers/pci/device.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 use crate::{
     drivers::pci::{pci_read_long, pci_write_long, DeviceClass, PCICommonHeader, PCIHeader},
     errors::{CanFail, IOError},
-    println,
 };
 
 pub const BAR_32_WIDTH: u32 = 0x00;
@@ -344,7 +343,6 @@ impl<'d> PCIDevice<'d> {
     }
 
     pub fn interrupt_line(&self) -> u8 {
-        println!("l = {}", self.read_confl(INTERRUPT_WOFFSET));
         (self.read_confl(INTERRUPT_WOFFSET) & 0xff) as u8
     }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -12,6 +12,7 @@
 
 use core::{fmt::Debug, slice};
 
+use crate::drivers::ide::AtaDeviceIdentifier;
 use alloc::sync::Arc;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use spin::RwLock;
@@ -46,7 +47,7 @@ pub(crate) trait Fs {
     ///
     /// - Disk I/O error
     fn mount(
-        drive_id: usize,
+        drive_id: AtaDeviceIdentifier,
         partition_id: usize,
         partition_data: u64,
     ) -> Result<Arc<RwLock<Self>>, MountError>;
@@ -59,7 +60,7 @@ pub(crate) trait Fs {
     ///
     /// May return any variant of [`IOError`] in case of failure.
     /// Usually, errors are caused by disk / driver failures.
-    fn identify(drive_id: usize, partition_data: u64) -> IOResult<bool>;
+    fn identify(drive_id: AtaDeviceIdentifier, partition_data: u64) -> IOResult<bool>;
 }
 
 /// A file-system independent file. This provides a basic set of functionalities when working with

--- a/src/fs/partitions/mod.rs
+++ b/src/fs/partitions/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Contains the implementation of the two standards partition scheme, _GPT_ and _MBR_.
 
+use crate::drivers::ide::AtaDeviceIdentifier;
 use crate::errors::{CanFail, MountError};
 use crate::fs::{
     ext4::Ext4Fs,
@@ -21,7 +22,7 @@ pub mod mbr;
 #[derive(Clone)]
 pub struct Partition {
     id: usize,
-    drive_id: usize,
+    drive_id: AtaDeviceIdentifier,
     metadata: PartitionMetadata,
     pub fs: PartFS,
 }
@@ -30,7 +31,7 @@ impl Partition {
     /// Loads a `Partition` from a _MBR_ partition table entry.
     pub fn from_metadata(
         part_id: usize,
-        drive_id: usize,
+        drive_id: AtaDeviceIdentifier,
         metadata: PartitionMetadata,
     ) -> Option<Self> {
         Some(Self {

--- a/src/x86/real/boot.S
+++ b/src/x86/real/boot.S
@@ -1,4 +1,4 @@
-#define BOOT_SECTORS_COUNT 0xA00
+#define BOOT_SECTORS_COUNT 0x400
 #define BOOTSTRAP_SECTORS_COUNT 0x3
 #define MAX_SECTORS_PER_READ 0x80
 #define MAX_DISK_OP_RETRIES 5
@@ -50,6 +50,7 @@ ext_load_boot:
     mov ah, 0x42
     int 0x13
     jc read_loop
+    xor al, al
     sub bx, dap_sectors_count
     add cx, MAX_SECTORS_PER_READ
     add WORD PTR dap_segment, MAX_SECTORS_PER_READ * 0x20


### PR DESCRIPTION
Implemented `DiskDevice`, a standard trait through which one can interact with disk devices.

Disk devices now have a unique identifier (based among other things on the technology of the underlying physical device), and can be retrieved using that identifier and the `get_sata_drive` function, that returns a virtual structure that emulates the capacity of a standard physical disk device, but actually forwards the request to an actual physical device depending on the technology used (IDE, AHCI).