### PR TITLE
feat(panic-handling): implement kernel panic message

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Cforce-frame-pointers=yes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hashbrown = "0.14.5"
 modular-bitfield = "0.11"
 noto-sans-mono-bitmap = "0.2"
 conquer-once = { version = "0.4", default-features = false }
+unifont = "1.1"
 fzproc_macros = { path = "src/fzboot/proc_macros" }
 vob = { path = "src/deps/vob", features = ["unsafe_internals"] }
 acpi = { path = "src/deps/acpi/acpi" }

--- a/src/fzboot/exceptions/mod.rs
+++ b/src/fzboot/exceptions/mod.rs
@@ -1,0 +1,1 @@
+pub mod panic;

--- a/src/fzboot/exceptions/mod.rs
+++ b/src/fzboot/exceptions/mod.rs
@@ -1,1 +1,22 @@
+use exception_vectors::DOUBLE_FAULT;
+use fzproc_macros::interrupt_handler;
+use panic::panic_entry_exception;
+
+use crate::irq::manager::get_interrupt_manager;
+
 pub mod panic;
+
+pub mod exception_vectors {
+    use crate::x86::apic::InterruptVector;
+
+    pub const DOUBLE_FAULT: InterruptVector = InterruptVector::new(0x8);
+}
+
+pub fn register_exception_handlers() {
+    get_interrupt_manager().register_static_handler(DOUBLE_FAULT, double_fault_handler);
+}
+
+#[interrupt_handler(exception = true)]
+pub fn double_fault_handler(frame: ExceptionStackFrame) {
+    panic_entry_exception("DOUBLE_FAULT", frame)
+}

--- a/src/fzboot/exceptions/panic.rs
+++ b/src/fzboot/exceptions/panic.rs
@@ -1,0 +1,77 @@
+use core::{
+    fmt::Write,
+    hint,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use alloc::format;
+use fzproc_macros::interrupt_handler;
+
+use crate::{
+    irq::manager::get_interrupt_manager,
+    mem::{MemoryAddress, PhyAddr},
+    video::vesa::{framebuffer::RgbaColor, text_buffer},
+    x86::{
+        apic::InterruptVector,
+        descriptors::idt::{GateDescriptor, GateType, InterruptDescriptorTable},
+        int::enable_interrupts,
+    },
+};
+
+static KEY_PRESSED: AtomicBool = AtomicBool::new(false);
+
+/// Entry point when the kernel explicity panics (usually through the [`core::panic`] macro).
+///
+/// Only displays the message given at the panic call site, contrary to exceptions handlers that display more
+/// information about the current state of the system.
+pub fn panic_entry_no_exception(error_msg: &str) -> ! {
+    unsafe {
+        text_buffer().buffer.force_unlock();
+    }
+    let mut text_buffer: spin::MutexGuard<crate::video::vesa::framebuffer::TextFrameBuffer<'_>> =
+        text_buffer().buffer.lock();
+
+    text_buffer.set_background(Some(RgbaColor(255, 50, 50, 0)));
+    text_buffer.clear();
+
+    text_buffer.write_str_bitmap_centered("KERNEL PANIC", true);
+
+    text_buffer.write_str("\n");
+
+    text_buffer.write_str_bitmap(
+        "The system encountered a fatal exception and cannot continue properly. \n\n",
+    );
+
+    let register_dump = format!("EXPLICIT_PANIC: {}\n", error_msg);
+    text_buffer.write_str_bitmap(&register_dump);
+
+    text_buffer.write_str("\n\n\n");
+    text_buffer.write_str_bitmap_centered("Press any key to reboot", false);
+
+    #[interrupt_handler]
+    fn kb_handler(frame: InterruptStackFrame) {
+        KEY_PRESSED.store(true, Ordering::Release);
+    }
+
+    get_interrupt_manager().register_static_handler(InterruptVector::from(0x21), kb_handler);
+    enable_interrupts();
+
+    unsafe {
+        get_interrupt_manager().load_idt();
+    }
+
+    while !KEY_PRESSED.load(Ordering::Relaxed) {
+        hint::spin_loop();
+    }
+
+    unsafe {
+        let mut dummy_idt =
+            InterruptDescriptorTable::<PhyAddr>::new(PhyAddr::NULL_PTR + 0x1000_usize);
+        dummy_idt.set_entry(0x20, GateDescriptor::new(GateType::InterruptGate));
+
+        dummy_idt.write_table();
+        dummy_idt.enable();
+    }
+
+    loop {}
+}

--- a/src/fzboot/irq/mod.rs
+++ b/src/fzboot/irq/mod.rs
@@ -35,16 +35,36 @@ pub(crate) struct InterruptStackFrame {
     pub(crate) registers: GeneralPurposeRegisters,
 }
 
+/// Content of the _Exception Stack Frame_, set up by the CPU when an exception that defines an error code
+/// is raised.
+///
+/// It differs from a usual [`InterruptStackFrame`] with the presence of an error code, pushed when the exception
+/// is raised.
+///
+/// Interrupt handlers with `exception` set as true receive this structure as their first argument.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ExceptionStackFrame {
-    register_dump: GeneralPurposeRegisters,
-    error_code: u64,
-    rip: VirtAddr,
-    cs: u64,
-    rflags: u64,
-    stack_ptr: VirtAddr,
-    stack_segment: u64,
+    /// Error code associated with the exception.
+    pub(crate) error_code: u64,
+
+    /// Saved content of the `RIP` (_instruction pointer_ register) prior to the exception.
+    pub(crate) rip: VirtAddr,
+
+    /// Saved content of the `CS` (_code segment_ register) prior to the exception.
+    pub(crate) cs: u64,
+
+    /// Saved content of the `RFLAGS` register prior to the exception.
+    pub(crate) rflags: u64,
+
+    /// Saved value of the stack pointer (`RSP`) prior to the exception.
+    pub(crate) stack_ptr: VirtAddr,
+
+    /// Saved value of the stack segment (`SS`) prior to the exception.
+    pub(crate) stack_segment: u64,
+
+    /// Saved values of all general purpose registers.
+    pub(crate) registers: GeneralPurposeRegisters,
 }
 
 // todo: restore locks afterwards

--- a/src/fzboot/main/src/main.rs
+++ b/src/fzboot/main/src/main.rs
@@ -17,7 +17,7 @@ use fzboot::drivers::generics::dev_disk::{sata_drives, DiskDevice};
 use fzboot::drivers::ide::AtaDeviceIdentifier;
 use fzboot::fs::partitions::mbr;
 use fzboot::irq::manager::{get_interrupt_manager, get_prot_interrupt_manager};
-use fzboot::mem::MemoryAddress;
+use fzboot::mem::{MemoryAddress, VirtAddr};
 use fzboot::video::vesa::{init_text_buffer_from_vesa, text_buffer};
 use fzboot::x86::apic::InterruptVector;
 use fzboot::x86::descriptors::gdt::long_init_gdt;
@@ -86,7 +86,7 @@ pub fn boot_main() -> ! {
     unsafe {
         long_init_gdt();
         asm!("mov ecx, {}", in(reg) mb_information_hdr_addr);
-        asm!("push 0x10", "push 0x800000", "retf");
+        asm!("mov ebp, 0", "push 0x10", "push 0x8000000", "retf");
         core::unreachable!();
     }
 }

--- a/src/fzboot/mod.rs
+++ b/src/fzboot/mod.rs
@@ -1,4 +1,5 @@
 mod err;
+pub mod exceptions;
 #[cfg(feature = "alloc")]
 pub mod irq;
 pub mod time;

--- a/src/fzboot/mod.rs
+++ b/src/fzboot/mod.rs
@@ -1,4 +1,5 @@
 mod err;
+#[cfg(feature = "x86_64")]
 pub mod exceptions;
 #[cfg(feature = "alloc")]
 pub mod irq;

--- a/src/x86/apic/local_apic.rs
+++ b/src/x86/apic/local_apic.rs
@@ -260,6 +260,10 @@ pub struct InterruptVector(u8);
 impl InterruptVector {
     /// Spurious vector interrupt vector.
     pub(super) const SPURIOUS_VECTOR: Self = Self(0xFF);
+
+    pub const fn new(vector: u8) -> Self {
+        Self(vector)
+    }
 }
 
 impl From<u8> for InterruptVector {

--- a/src/x86/descriptors/idt.rs
+++ b/src/x86/descriptors/idt.rs
@@ -14,10 +14,8 @@ use modular_bitfield::{
 use crate::{
     error,
     errors::{BaseError, CanFail},
-    mem::{MemoryAddress, PhyAddr},
-    println,
+    mem::MemoryAddress,
     x86::{
-        descriptors::idt,
         int::{disable_interrupts, enable_interrupts, interrupts_disabled},
         privilege::PrivilegeLevel,
     },


### PR DESCRIPTION
Various panic / exceptions related code.

- Implements a new kernel panic message displayed on exceptions / explicit panic, showing debugging information
- Shows a stack trace on panic / exceptions
- Add the `InterruptStackFrame` and `ExceptionStackFrame` to retrieve the stack frame generated by the CPU when an interrupt / exception is raised.